### PR TITLE
Fixed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "now": "now --token=$NOW_TOKEN"
   },
   "dependencies": {
+    "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.47",
     "@zeit/next-css": "0.2.0",
     "file-loader": "1.1.11",
     "jss": "9.8.1",
@@ -27,7 +28,6 @@
     "react-jss": "8.4.0"
   },
   "devDependencies": {
-    "@babel/plugin-transform-flow-strip-types": "7.0.0-beta.47",
     "eslint": "4.19.1",
     "eslint-config-henribeck": "4.19.5",
     "flow-bin": "0.72.0",


### PR DESCRIPTION
Moved @babel/plugin-transform-flow-strip-types to the dependencies so the build on the server wouldn't fail